### PR TITLE
Add nodiscard attribute to PushNativesScope and CreateNativesContext

### DIFF
--- a/IResource.h
+++ b/IResource.h
@@ -80,7 +80,9 @@ namespace alt
 
 #ifdef ALT_CLIENT_API
 		virtual void EnableNatives() = 0;
+		[[nodiscard]]
 		virtual Ref<INative::Context> CreateNativesContext() const = 0;
+		[[nodiscard]]
 		virtual Ref<INative::Scope> PushNativesScope() = 0;
 
 		virtual ILocalStorage *GetLocalStorage() = 0;


### PR DESCRIPTION
These functions will not work as expected if you discard the return value, so these attributes now force the compiler to throw an error if the return value is discarded.
The exact problem happened when the lua client module was developed, and caused a lot of debugging time, this attribute would clearly show a warning to indicate it will not work as expected.
This needs atleast C++17 to work, which might be unwanted.