### PR TITLE
Split ifdef directive in IVehicle

### DIFF
--- a/objects/IVehicle.h
+++ b/objects/IVehicle.h
@@ -154,7 +154,8 @@ namespace alt
 		virtual void LoadHealthDataFromBase64(StringView base64) = 0;
 		virtual Ref<IVehicle> GetAttached() const = 0;
 		virtual Ref<IVehicle> GetAttachedTo() const = 0;
-#else
+#endif
+#ifdef ALT_CLIENT_API
 		virtual float GetWheelSpeed() const = 0;
 		virtual uint16_t GetCurrentGear() const = 0;
 		virtual float GetCurrentRPM() const = 0;

--- a/objects/IVehicle.h
+++ b/objects/IVehicle.h
@@ -155,6 +155,7 @@ namespace alt
 		virtual Ref<IVehicle> GetAttached() const = 0;
 		virtual Ref<IVehicle> GetAttachedTo() const = 0;
 #endif // ALT_SERVER_API
+
 #ifdef ALT_CLIENT_API
 		virtual float GetWheelSpeed() const = 0;
 		virtual uint16_t GetCurrentGear() const = 0;

--- a/objects/IVehicle.h
+++ b/objects/IVehicle.h
@@ -154,7 +154,7 @@ namespace alt
 		virtual void LoadHealthDataFromBase64(StringView base64) = 0;
 		virtual Ref<IVehicle> GetAttached() const = 0;
 		virtual Ref<IVehicle> GetAttachedTo() const = 0;
-#endif
+#endif // ALT_SERVER_API
 #ifdef ALT_CLIENT_API
 		virtual float GetWheelSpeed() const = 0;
 		virtual uint16_t GetCurrentGear() const = 0;
@@ -172,7 +172,7 @@ namespace alt
 
 		virtual uint8_t GetLightsIndicator() const = 0;
 		virtual void SetLightsIndicator(uint8_t lightsIndicatorFlag) = 0;
-#endif
+#endif // ALT_CLIENT_API
 		
 		const std::type_info& GetTypeInfo() const override { return typeid(this); }
 	};


### PR DESCRIPTION
The `#else` makes IDEs confused when you define both macros (when e.g. working on a shared module)
So now it works properly like in all the other classes.