### PR TITLE
Move RegisterScriptRuntime under server methods

### DIFF
--- a/ICore.h
+++ b/ICore.h
@@ -82,8 +82,6 @@ namespace alt
 
 		virtual uint32_t Hash(const std::string& str) const = 0;
 
-		virtual bool RegisterScriptRuntime(const std::string& resourceType, IScriptRuntime *runtime) = 0;
-
 		virtual bool SubscribeCommand(const std::string& cmd, CommandCallback cb) = 0;
 
 		virtual bool FileExists(const std::string& path) = 0;
@@ -277,6 +275,8 @@ namespace alt
 
 #ifdef ALT_SERVER_API // Server methods
 		virtual const std::string& GetRootDirectory() = 0;
+		
+		virtual bool RegisterScriptRuntime(const std::string& resourceType, IScriptRuntime *runtime) = 0;
 
 		virtual IResource *StartResource(const std::string& name) = 0;
 		virtual void StopResource(const std::string& name) = 0;


### PR DESCRIPTION
The alt::ICore::RegisterScriptRuntime function, has no use on client and crashes server if ALT_SERVER_API is not defined while compiling.

I don't see any reason why it should be present in shared functions instead of server ones. Of course if there is any reason to keep it there then just close this PR.