### PR TITLE
Fix CClientRequestObjectEvent methods

### DIFF
--- a/events/CClientRequestObjectEvent.h
+++ b/events/CClientRequestObjectEvent.h
@@ -24,8 +24,8 @@ namespace alt
 		}
 
 		IPlayer* GetTarget() const { return target.get(); }
-		const uint32_t& GetModel() const { return model; }
-		const alt::Position& GetPosition() const { return position; }
+		uint32_t GetModel() const { return model; }
+		alt::Position GetPosition() const { return position; }
 
 	private:
 		std::shared_ptr<IPlayer> target;


### PR DESCRIPTION
Fix for consistency of all sdk, see other events: https://github.com/altmp/cpp-sdk/blob/a8e78db18bcb071cf56758c332a68c5861582028/events/CStartProjectileEvent.h#L26-L30